### PR TITLE
Feature zoom

### DIFF
--- a/build/d3-geo-scale-bar.js
+++ b/build/d3-geo-scale-bar.js
@@ -3021,41 +3021,38 @@
         feature,
         mG,
         miles,
+        milesText,
         milesTickValues,
         milesRadius = 3959,
         height = 4,
         left = 0,
         top = 0,
-        scaleFactor = 1;
+        scaleFactor = 1, // new
+        barHeight = 6, // new
+        barFrame; // new
 
     function scaleBar(context){
       var bounds = geoBounds(feature);
-
-      // debugger
 
       // Calculate the geo height in pixel.
       var vert_point_a_projected = projection$$1([0, bounds[0][1]]);
       var vert_point_b_projected = projection$$1([0, bounds[1][1]]);
       var height_projected = Math.abs(vert_point_a_projected[1] - vert_point_b_projected[1]);
 
-      // Calculate the geo width in miles.
+      // Calculate the geo width in radians.
       var bottom = Math.abs((bounds[1][1] - bounds[0][1]) * top);
       var point_a = [bounds[0][0], bottom];
       var point_b = [bounds[1][0], bottom];
       var distance_radians = distance(point_a, point_b);
 
-      var distance_miles = distance_radians * milesRadius;
-
       // Calulate the geo width in pixel.
       var point_a_projected = projection$$1(point_a);
       var point_b_projected = projection$$1(point_b);
       var width_projected = point_b_projected[0] - point_a_projected[0];
-      
-      // Calculete a reasonable miles value. TODO OLD.
-      // miles = miles * 1/scaleFactor || Math.pow(10, countDigits(distance_miles) - 1);
-      // var miles_proportion_of_whole = miles / distance_miles;
-      // var miles_width_of_bar = miles_proportion_of_whole * width_projected;
 
+      // Calulate the geo width in miles.
+      var distance_miles = distance_radians * milesRadius;
+      
       // Calculete a reasonable initial miles value. 
       var initialMiles = miles || Math.pow(10, countDigits(distance_miles) - 1);
 
@@ -3067,9 +3064,6 @@
       var top_of_bar = Math.min(vert_point_a_projected[1], vert_point_b_projected[1]) + (height_projected * top);
       var left_of_bar = Math.min(point_a_projected[0], point_b_projected[0]) + (width_projected * left);
 
-      // Not necessary:
-      // context.attr("width", extent[0]).attr("height", extent[1]);
-
       // Calculate the initial, static scale.
       var milesScaleInitial = linear$1()
         .domain([0, initialMiles])
@@ -3077,86 +3071,60 @@
       var rMaxNew = miles_width_of_bar / scaleFactor;
       var dMaxNew = milesScaleInitial.invert(rMaxNew);
 
-      // console.log(initialMiles, miles_width_of_bar, appliedMiles);
-      // console.log(dMaxNew)
-      // if (scaleFactor > 2) debugger
-
+      // Calculate the updated scale.
       var milesScale = linear$1()
         .domain([0, dMaxNew])
         .range([0, miles_width_of_bar]);
 
+      // Set axis.
       var milesAxis = axisBottom(milesScale)
-        // .tickValues(milesTickValues ? milesTickValues : [0, appliedMiles / 4, appliedMiles / 2, appliedMiles])
-        // .tickValues(milesTickValues ? milesTickValues : [0, dMaxNew / 4, dMaxNew / 2, dMaxNew])
-        // .tickValues(milesTickValues ? milesTickValues : [0, initialMiles / 4, initialMiles / 2, initialMiles])
         .ticks(5)
         .tickSize(0)
-        .tickPadding(6);
+        .tickPadding(Math.max(8, barHeight**1/1.5)); // minimum of 8, increments decreasing for higher bars.
 
+      // Draw axis.
       mG = mG || context.append("g")
-          .attr("class", "miles");
+        .attr("class", "miles");
 
       mG
-          .attr("transform", "translate(" + left_of_bar + ", " + (top_of_bar + 14) + ")")
-          .call(milesAxis);
+        .attr("transform", "translate(" + left_of_bar + ", " + (top_of_bar + 20) + ")")
+        .call(milesAxis);
 
-
-      // d3.selectAll('.line-dash').remove();
-
+      // Calculate tick distances.
       var tickValues = d3.selectAll('.tick').data();
       var tickLength = tickValues.length;
       var lastValue = tickValues.filter((d,i,data) => i === data.length-1)[0];
       var lastValuePixel = milesScale(lastValue);
-      var dashLengthPixel = lastValuePixel / (tickLength - 1);
+      var tickDistance = lastValuePixel / (tickLength - 1);
 
-
+      // Adapt domain path (we need to remove the 0.5 pixel vertical lines).
       var domainPath = d3.select('.domain');
+      domainPath.attr('d', domainPath.attr('d').replace('V0.5', 'V0'));
 
+      // Add dash-array.
       domainPath
-        .style('stroke-width', 6)
-        .style('stroke-dashoffset', -3.5)
-        .style('stroke-dasharray', `${dashLengthPixel}, ${dashLengthPixel}`);
+        .style('stroke-width', barHeight)
+        .style('stroke-dashoffset', 0)
+        .style('stroke-dasharray', `${tickDistance}, ${tickDistance}`);
 
+      // Add bar frame.
+      barFrame = barFrame || mG
+        .append('rect')
+        .attr('class', 'bar-frame')
+        .attr('y', -barHeight / 2)
+        .attr('width', miles_width_of_bar)
+        .attr('height', barHeight)
+        .style('fill', 'none')
+        .style('stroke-width', 0.3);
 
-
-      // console.log(tickLength, lastValue, lastValuePixel, dashLengthPixel);
-
-      // var mL = mG.append('line')
-      //   .attr('class', 'line-dash')
-      //   .attr('x0', 0)
-      //   .attr('x1', miles_width_of_bar)
-      //   .style('stroke-width', 5)
-      //   .style('stroke', 'tomato')
-      //   .style('stroke-dashoffset', '0%')
-      //   .style('stroke-dasharray', `${dashLengthPixel}, ${dashLengthPixel}`)
-
-
-
-      // var rectData = milesAxis.tickValues()
-      //   .map(function(d, i, data) { return [d, data[i + 1]]; })
-      //   .filter(function(d, i, data) { return i !== data.length - 1; })
-
-
-      // var milesRects = mG.selectAll("rect")
-      //     .data(rectData);
-
-      // milesRects.exit().remove();
-
-      // milesRects.enter().append("rect")
-      //     .attr("height", height)
-      //     .style("stroke", "#000")
-      //     .style("fill", function(d, i){ return i % 2 === 0 ? "#000" : "#fff"; })
-      //   .merge(milesRects)
-      //     .attr("x", function(d){ return milesScale(d[0]); })
-      //     .attr("width", function(d){ return milesScale(d[1] - d[0]); });
-
-      // milesText = milesText || mG.append("text")
-      //   .attr("class", "label")
-      //   .style("fill", "#000")
-      //   .style("text-anchor", "start")
-      //   .style("font-size", "12px")
-      //   .attr("y", -4)
-      //   .text("Miles");
+      // Add miles text.
+      milesText = milesText || mG.append("text")
+        .attr("class", "label")
+        .style("fill", "#000")
+        .style("text-anchor", "start")
+        .style("font-size", "12px")
+        .attr("y", -8)
+        .text("Miles");
 
 
     }
@@ -3204,7 +3172,11 @@
     };
 
     scaleBar.scaleFactor = function(_) {
-      return arguments.length ? (scaleFactor = _) : scaleFactor;
+      return arguments.length ? (scaleFactor = _, scaleBar) : scaleFactor;
+    };
+
+    scaleBar.barHeight = function(_) {
+      return arguments.length ? (barHeight = _, scaleBar) : barHeight;
     };
 
     function countDigits(_){

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "https://github.com/HarryStevens/d3-geo-scale-bar"
   },
   "scripts": {
+    "watch": "rollup --config rollup.config.js --watch",
     "pretest": "rm -rf build && mkdir build && rollup -c --banner \"$(preamble)\"",
     "test": "tape 'test/**/*-test.js' && eslint index.js src",
     "prepublish": "npm run test && uglifyjs build/d3-geo-scale-bar.js -c -m -o build/d3-geo-scale-bar.min.js",

--- a/src/buildAxis.js
+++ b/src/buildAxis.js
@@ -1,0 +1,73 @@
+import { axisBottom } from 'd3-axis';
+
+function titleCase(string) {
+  return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+/**
+ * Draws legend axis.
+ * @param  {string}      selector  Name of unit (e.g. "miles")
+ * @param  {Object}      position  Left and top bar position.
+ * @param  {function}    scale     D3 scale function.
+ * @param  {Selection}   context   Parent g.
+ * @param  {number}      barWidth  Bar width in pixel.
+ * @param  {number}      barHeight Bar height in pixel.
+ * @return {undefined}             DOM side effects.
+ */
+export default function buildAxis(
+  selector,
+  position,
+  scale,
+  context,
+  barWidth,
+  barHeight
+) {
+  // Set axis.
+  var axis = axisBottom(scale)
+    .ticks(5)
+    .tickSize(0)
+    // minimum of 8, increments decrease for higher bars:
+    .tickPadding(Math.max(8, barHeight ** 1 / 1.5)); 
+
+  // Build legend g only on initialization.
+  var gUpdate = context.selectAll('g.' + selector).data([1]);
+  var g = gUpdate.enter().append('g').attr('class', selector);
+
+  // Draw axis (re-select as g is empty on update).
+  d3.select('g.' + selector)
+    .attr('transform', 'translate(' + position.left + ', ' + position.top + ')')
+    .call(axis);
+
+  // Calculate tick distances.
+  var tickValues = d3.selectAll('.' + selector + ' .tick').data();
+  var lastValue = tickValues.filter((d, i, data) => i === data.length - 1)[0];
+  var lastValuePixel = scale(lastValue);
+  var tickDistance = lastValuePixel / (tickValues.length - 1);
+
+  // Adapt domain path (we need to remove the 0.5 pixel vertical lines).
+  var domainPath = d3.select('.' + selector + ' .domain');
+  domainPath.attr('d', domainPath.attr('d').replace('V0.5', 'V0'));
+
+  // Add dash-array.
+  domainPath
+    .style('stroke-width', barHeight)
+    .style('stroke-dashoffset', 0)
+    .style('stroke-dasharray', `${tickDistance}, ${tickDistance}`);
+
+  // Add bar frame.
+  g.append('rect')
+    .attr('class', 'bar-frame')
+    .attr('y', -barHeight / 2)
+    .attr('width', barWidth)
+    .attr('height', barHeight)
+    .style('fill', 'none');
+
+  // Add miles text.
+  g.append('text')
+    .attr('class', 'bar-label')
+    .style('fill', '#000')
+    .style('text-anchor', 'start')
+    .style('font-size', '12px')
+    .attr('y', -8)
+    .text(titleCase(selector));
+}

--- a/src/geoScaleBar.js
+++ b/src/geoScaleBar.js
@@ -1,22 +1,25 @@
 import {geoBounds, geoDistance} from "d3-geo";
-import {scaleLinear} from "d3-scale";
-import {axisBottom} from "d3-axis";
+import getUnitMeasures from './getUnitMeasures'
+import getScale from './getScale'
+import buildAxis from './buildAxis'
 
 export default function(){
+
+  // Exposed.
   var extent,
-      projection,
       feature,
-      mG,
+      projection,
       miles,
-      milesText,
-      milesTickValues,
       milesRadius = 3959,
-      height = 4,
+      milesTickValues,
+      kilometres,
+      kilometresRadius = 6371,
+      kilometresTickValues,
+      height = 0,
       left = 0,
       top = 0,
-      scaleFactor = 1, // new
-      barHeight = 6, // new
-      barFrame; // new
+      scaleFactor = 1,
+      barHeight = 6;
 
   function scaleBar(context){
     var bounds = geoBounds(feature);
@@ -37,86 +40,37 @@ export default function(){
     var point_b_projected = projection(point_b);
     var width_projected = point_b_projected[0] - point_a_projected[0];
 
-    // Calulate the geo width in miles.
-    var distance_miles = distance_radians * milesRadius;
-    
-    // Calculete a reasonable initial miles value. 
-    var initialMiles = miles || Math.pow(10, countDigits(distance_miles) - 1);
-
-    // Calculate the bar width for the range (which will remain).
-    var miles_proportion_of_whole = initialMiles / distance_miles;
-    var miles_width_of_bar = miles_proportion_of_whole * width_projected;
-
     // Set the width and height of the g element.
     var top_of_bar = Math.min(vert_point_a_projected[1], vert_point_b_projected[1]) + (height_projected * top);
     var left_of_bar = Math.min(point_a_projected[0], point_b_projected[0]) + (width_projected * left);
 
-    // Calculate the initial, static scale.
-    var milesScaleInitial = scaleLinear()
-      .domain([0, initialMiles])
-      .range([0, miles_width_of_bar]); 
+    // Get key measures.
+    var measuresMiles = getUnitMeasures(distance_radians, milesRadius, miles, width_projected);
+    var measuresKilometres = getUnitMeasures(distance_radians, kilometresRadius, kilometres, width_projected);
 
-    // Calculate the scaled miles.
-    var appliedMiles = initialMiles * scaleFactor;
-    var rMaxNew = miles_width_of_bar / scaleFactor;
-    var dMaxNew = milesScaleInitial.invert(rMaxNew)
+    // Get a zoom factor aware scale.
+    var scaleMiles = getScale(measuresMiles.domainMax, measuresMiles.barWidth, scaleFactor);
+    var scaleKilometres = getScale(measuresKilometres.domainMax, measuresKilometres.barWidth, scaleFactor);
 
-    // Calculate the updated scale.
-    var milesScale = scaleLinear()
-      .domain([0, dMaxNew])
-      .range([0, miles_width_of_bar])
+    // Draw the miles axis.
+    buildAxis(
+      'miles', 
+      {left: left_of_bar, top: (top_of_bar + 20)},
+      scaleMiles, 
+      context, 
+      measuresMiles.barWidth,
+      barHeight
+    )
 
-    // Set axis.
-    var milesAxis = axisBottom(milesScale)
-      .ticks(5)
-      .tickSize(0)
-      .tickPadding(Math.max(8, barHeight**1/1.5)); // minimum of 8, increments decreasing for higher bars.
-
-    // Draw axis.
-    mG = mG || context.append("g")
-      .attr("class", "miles");
-
-    mG
-      .attr("transform", "translate(" + left_of_bar + ", " + (top_of_bar + 20) + ")")
-      .call(milesAxis);
-
-    // Calculate tick distances.
-    var tickValues = d3.selectAll('.tick').data();
-    var tickLength = tickValues.length;
-    var lastValue = tickValues.filter((d,i,data) => i === data.length-1)[0]
-    var lastValuePixel = milesScale(lastValue);
-    var tickDistance = lastValuePixel / (tickLength - 1)
-
-    // Adapt domain path (we need to remove the 0.5 pixel vertical lines).
-    var domainPath = d3.select('.domain');
-    domainPath.attr('d', domainPath.attr('d').replace('V0.5', 'V0'));
-
-    // Add dash-array.
-    domainPath
-      .style('stroke-width', barHeight)
-      .style('stroke-dashoffset', 0)
-      .style('stroke-dasharray', `${tickDistance}, ${tickDistance}`);
-
-    // Add bar frame.
-    barFrame = barFrame || mG
-      .append('rect')
-      .attr('class', 'bar-frame')
-      .attr('y', -barHeight / 2)
-      .attr('width', miles_width_of_bar)
-      .attr('height', barHeight)
-      .style('fill', 'none')
-      .style('stroke-width', 0.3);
-
-    // Add miles text.
-    milesText = milesText || mG.append("text")
-      .attr("class", "label")
-      .style("fill", "#000")
-      .style("text-anchor", "start")
-      .style("font-size", "12px")
-      .attr("y", -8)
-      .text("Miles");
-
-
+    // Draw the kilometres axis.
+    buildAxis(
+      'kilometres', 
+      {left: left_of_bar, top: (top_of_bar + 60)},
+      scaleKilometres, 
+      context, 
+      measuresKilometres.barWidth,
+      barHeight
+    )
   }
 
   scaleBar.fitSize = function(e, o){
@@ -149,6 +103,18 @@ export default function(){
     return arguments.length ? (milesTickValues = _, scaleBar) : milesTickValues;
   }
 
+  scaleBar.kilometres = function(_) {
+    return arguments.length ? (kilometres = +_, scaleBar) : kilometres;
+  }
+
+  scaleBar.kilometresRadius = function(_) {
+    return arguments.length ? (kilometresRadius = +_, scaleBar) : kilometresRadius;
+  }
+
+  scaleBar.kilometresTickValues = function(_) {
+    return arguments.length ? (kilometresTickValues = _, scaleBar) : kilometresTickValues;
+  }
+
   scaleBar.height = function(_) {
     return arguments.length ? (height = +_, scaleBar) : height;
   }
@@ -167,10 +133,6 @@ export default function(){
 
   scaleBar.barHeight = function(_) {
     return arguments.length ? (barHeight = _, scaleBar) : barHeight;
-  }
-
-  function countDigits(_){
-    return Math.floor(_).toString().length;
   }
 
   return scaleBar;

--- a/src/geoScaleBar.js
+++ b/src/geoScaleBar.js
@@ -11,55 +11,78 @@ export default function(){
       milesText,
       milesTickValues,
       milesRadius = 3959,
-      kG,
-      kilometers,
-      kilometersTickValues,
-      kilometersText,
-      kilometersRadius = 6371,
       height = 4,
       left = 0,
-      top = 0;
+      top = 0,
+      scaleFactor = 1;
 
   function scaleBar(context){
     var bounds = geoBounds(feature);
 
+    // debugger
+
+    // Calculate the geo height in pixel.
     var vert_point_a_projected = projection([0, bounds[0][1]]);
     var vert_point_b_projected = projection([0, bounds[1][1]]);
     var height_projected = Math.abs(vert_point_a_projected[1] - vert_point_b_projected[1]);
 
+    // Calculate the geo width in miles.
     var bottom = Math.abs((bounds[1][1] - bounds[0][1]) * top);
     var point_a = [bounds[0][0], bottom];
     var point_b = [bounds[1][0], bottom];
     var distance_radians = geoDistance(point_a, point_b)
 
     var distance_miles = distance_radians * milesRadius;
-    var distance_kilometers = distance_radians * kilometersRadius;
 
+    // Calulate the geo width in pixel.
     var point_a_projected = projection(point_a);
     var point_b_projected = projection(point_b);
     var width_projected = point_b_projected[0] - point_a_projected[0];
     
-    // A very simple algorith for determining a good mileage / kilometerage. This can be overridden.
-    miles = miles || Math.pow(10, countDigits(distance_miles) - 1);
-    var miles_proportion_of_whole = miles / distance_miles;
+    // Calculete a reasonable miles value. TODO OLD.
+    // miles = miles * 1/scaleFactor || Math.pow(10, countDigits(distance_miles) - 1);
+    // var miles_proportion_of_whole = miles / distance_miles;
+    // var miles_width_of_bar = miles_proportion_of_whole * width_projected;
+
+    // Calculete a reasonable initial miles value. 
+    var initialMiles = miles || Math.pow(10, countDigits(distance_miles) - 1);
+
+    // Calculate the bar width for the range (which will remain).
+    var miles_proportion_of_whole = initialMiles / distance_miles;
     var miles_width_of_bar = miles_proportion_of_whole * width_projected;
 
-    kilometers = kilometers || Math.pow(10, countDigits(distance_kilometers) - 1);
-    var kilometers_proportion_of_whole = kilometers / distance_kilometers;
-    var kilometers_width_of_bar = kilometers_proportion_of_whole * width_projected;
-
+    // Set the width and height of the g element.
     var top_of_bar = Math.min(vert_point_a_projected[1], vert_point_b_projected[1]) + (height_projected * top);
     var left_of_bar = Math.min(point_a_projected[0], point_b_projected[0]) + (width_projected * left);
 
-    context.attr("width", extent[0]).attr("height", extent[1]);
+    // Not necessary:
+    // context.attr("width", extent[0]).attr("height", extent[1]);
+
+    // Calculate the initial, static scale.
+    var milesScaleInitial = scaleLinear()
+      .domain([0, initialMiles])
+      .range([0, miles_width_of_bar]); 
+
+    // Calculate the scaled miles.
+    var appliedMiles = initialMiles * scaleFactor;
+    var rMaxNew = miles_width_of_bar / scaleFactor;
+    var dMaxNew = milesScaleInitial.invert(rMaxNew)
+
+    // console.log(initialMiles, miles_width_of_bar, appliedMiles);
+    // console.log(dMaxNew)
+    // if (scaleFactor > 2) debugger
 
     var milesScale = scaleLinear()
+      .domain([0, dMaxNew])
       .range([0, miles_width_of_bar])
-      .domain([0, miles]);
 
     var milesAxis = axisBottom(milesScale)
-      .tickValues(milesTickValues ? milesTickValues : [0, miles / 4, miles / 2, miles])
-      .tickSize(height);
+      // .tickValues(milesTickValues ? milesTickValues : [0, appliedMiles / 4, appliedMiles / 2, appliedMiles])
+      // .tickValues(milesTickValues ? milesTickValues : [0, dMaxNew / 4, dMaxNew / 2, dMaxNew])
+      // .tickValues(milesTickValues ? milesTickValues : [0, initialMiles / 4, initialMiles / 2, initialMiles])
+      .ticks(5)
+      .tickSize(0)
+      .tickPadding(6);
 
     mG = mG || context.append("g")
         .attr("class", "miles");
@@ -68,61 +91,65 @@ export default function(){
         .attr("transform", "translate(" + left_of_bar + ", " + (top_of_bar + 14) + ")")
         .call(milesAxis);
 
-    var milesRects = mG.selectAll("rect")
-        .data(milesAxis.tickValues().map(function(d, i, data){ return [d, data[i + 1]]; }).filter(function(d, i, data){ return i !== data.length - 1; }));
 
-    milesRects.exit().remove();
+    // d3.selectAll('.line-dash').remove();
 
-    milesRects.enter().append("rect")
-        .attr("height", height)
-        .style("stroke", "#000")
-        .style("fill", function(d, i){ return i % 2 === 0 ? "#000" : "#fff"; })
-      .merge(milesRects)
-        .attr("x", function(d){ return milesScale(d[0]); })
-        .attr("width", function(d){ return milesScale(d[1] - d[0]); });
+    var tickValues = d3.selectAll('.tick').data();
+    var tickLength = tickValues.length;
+    var lastValue = tickValues.filter((d,i,data) => i === data.length-1)[0]
+    var lastValuePixel = milesScale(lastValue);
+    var dashLengthPixel = lastValuePixel / (tickLength - 1)
 
-    milesText = milesText || mG.append("text")
-      .attr("class", "label")
-      .style("fill", "#000")
-      .style("text-anchor", "start")
-      .style("font-size", "12px")
-      .attr("y", -4)
-      .text("Miles");
 
-    var kilometersScale = scaleLinear()
-      .range([0, kilometers_width_of_bar])
-      .domain([0, kilometers]);
+    var domainPath = d3.select('.domain');
 
-    var kilometersAxis = axisBottom(kilometersScale)
-      .tickValues(kilometersTickValues ? kilometersTickValues : [0, kilometers / 4, kilometers / 2, kilometers])
-      .tickSize(height);
+    domainPath
+      .style('stroke-width', 6)
+      .style('stroke-dashoffset', -3.5)
+      .style('stroke-dasharray', `${dashLengthPixel}, ${dashLengthPixel}`);
 
-    kG = kG || context.append("g")
-    kG
-        .attr("class", "kilometers")
-        .attr("transform", "translate(" + left_of_bar + ", " + (top_of_bar + 50) + ")")
-        .call(kilometersAxis);
 
-    var kilometersRects = kG.selectAll("rect")
-        .data(kilometersAxis.tickValues().map(function(d, i, data){ return [d, data[i + 1]]; }).filter(function(d, i, data){ return i !== data.length - 1; }));
 
-    kilometersRects.exit().remove();
+    // console.log(tickLength, lastValue, lastValuePixel, dashLengthPixel);
 
-    kilometersRects.enter().append("rect")
-        .attr("height", height)
-        .style("stroke", "#000")
-        .style("fill", function(d, i){ return i % 2 === 0 ? "#000" : "#fff"; })
-      .merge(kilometersRects)
-        .attr("x", function(d){ return kilometersScale(d[0]); })
-        .attr("width", function(d){ return kilometersScale(d[1] - d[0]); });
+    // var mL = mG.append('line')
+    //   .attr('class', 'line-dash')
+    //   .attr('x0', 0)
+    //   .attr('x1', miles_width_of_bar)
+    //   .style('stroke-width', 5)
+    //   .style('stroke', 'tomato')
+    //   .style('stroke-dashoffset', '0%')
+    //   .style('stroke-dasharray', `${dashLengthPixel}, ${dashLengthPixel}`)
 
-    kilometersText = kilometersText || kG.append("text")
-      .attr("class", "label")
-      .style("fill", "#000")
-      .style("text-anchor", "start")
-      .style("font-size", "12px")
-      .attr("y", -4)
-      .text("Kilometers");
+
+
+    // var rectData = milesAxis.tickValues()
+    //   .map(function(d, i, data) { return [d, data[i + 1]]; })
+    //   .filter(function(d, i, data) { return i !== data.length - 1; })
+
+
+    // var milesRects = mG.selectAll("rect")
+    //     .data(rectData);
+
+    // milesRects.exit().remove();
+
+    // milesRects.enter().append("rect")
+    //     .attr("height", height)
+    //     .style("stroke", "#000")
+    //     .style("fill", function(d, i){ return i % 2 === 0 ? "#000" : "#fff"; })
+    //   .merge(milesRects)
+    //     .attr("x", function(d){ return milesScale(d[0]); })
+    //     .attr("width", function(d){ return milesScale(d[1] - d[0]); });
+
+    // milesText = milesText || mG.append("text")
+    //   .attr("class", "label")
+    //   .style("fill", "#000")
+    //   .style("text-anchor", "start")
+    //   .style("font-size", "12px")
+    //   .attr("y", -4)
+    //   .text("Miles");
+
+
   }
 
   scaleBar.fitSize = function(e, o){
@@ -141,18 +168,6 @@ export default function(){
 
   scaleBar.projection = function(proj) {
     return arguments.length ? (projection = proj, scaleBar) : projection;
-  }
-
-  scaleBar.kilometers = function(_) {
-    return arguments.length ? (kilometers = +_, scaleBar) : kilometers;
-  }
-
-  scaleBar.kilometersRadius = function(_) {
-    return arguments.length ? (kilometersRadius = +_, scaleBar) : kilometersRadius;
-  }
-
-  scaleBar.kilometersTickValues = function(_) {
-    return arguments.length ? (kilometersTickValues = _, scaleBar) : kilometersTickValues;
   }
 
   scaleBar.miles = function(_) {
@@ -177,6 +192,10 @@ export default function(){
 
   scaleBar.top = function(_) {
     return arguments.length ? (top = _ > 1 ? 1 : _ < 0 ? 0 : +_, scaleBar) : top;
+  }
+
+  scaleBar.scaleFactor = function(_) {
+    return arguments.length ? (scaleFactor = _) : scaleFactor;
   }
 
   function countDigits(_){

--- a/src/getScale.js
+++ b/src/getScale.js
@@ -1,0 +1,22 @@
+import { scaleLinear } from 'd3-scale';
+
+/**
+ * Build the scale to use - considering the zoom scale k.
+ * @param  {number} domainMax Max distance in chosen unit (e.g. miles).
+ * @param  {number} unitBarWidth   Width of lagend bar in pixel.
+ * @param  {number} k              Zoom scale.
+ * @return {function}              D3 scale function.
+ */
+export default function getScale(domainMax, unitBarWidth, k) {
+  // Calculate the initial, static scale.
+  var scaleInitial = scaleLinear()
+    .domain([0, domainMax])
+    .range([0, unitBarWidth]);
+
+  // Calculate the scaled miles.
+  var rangeMaxNew = unitBarWidth / k;
+  var domainMaxNew = scaleInitial.invert(rangeMaxNew);
+
+  // Calculate the updated scale.
+  return scaleInitial.copy().domain([0, domainMaxNew]);
+}

--- a/src/getUnitMeasures.js
+++ b/src/getUnitMeasures.js
@@ -1,0 +1,31 @@
+function countDigits(_) {
+  return Math.floor(_).toString().length;
+}
+
+/**
+ * Calculate the max distance in the chosen unit to be displayed
+ * on the legend amd the legend width in pixels based on the max distance.
+ * @param  {number} distRadians      The geo distance in radians.
+ * @param  {number} unitRadius       The earth radius in the chosen unit.
+ * @param  {number} domainMax          The maximum unit distance to display initially.
+ * @param  {number} widthProjected   domainMax projected to pixel.
+ * @return {Object}                  Object holding the max distance in unit and pixel.
+ */
+export default function getUnitMeasures(
+  distRadians,
+  unitRadius,
+  domainMax,
+  widthProjected
+) {
+  // Calulate the geo width in chosen units (e.g. miles).
+  var distance = distRadians * unitRadius;
+
+  // Calculete a reasonable initial maximum unit value.
+  domainMax = domainMax || Math.pow(10, countDigits(distance) - 1);
+
+  // Calculate the bar width in pixel.
+  var unit_proportion_of_whole = domainMax / distance;
+  var unit_width_of_bar = unit_proportion_of_whole * widthProjected;
+
+  return { domainMax, barWidth: unit_width_of_bar };
+}


### PR DESCRIPTION


Hey Harry, as said, here are some potentially useful additions/changes (or not), mainly revolving around adding zoom, implementing the bar as a modified `.domain` path and decomposing the main function a little... 

Some notes to the additions: 

#### Zoom 


*d3-geo-scale-bar* will update on zoom, by allowing the user to set a `scaleFactor`. The `scaleFactor` defaults to 1 and doesn't have to be touched unless a user zooms. The user then just passes in the zoom transform's `k` value and re-calls the scale-bar like so:

```
function zoomed() {

  const t = d3.event.transform;

  scaleBar.scaleFactor(t.k);
  scale_bar.call(scaleBar);

}
```
Internally, the scale used for the legend axis just gets rescaled, similar to what d3-zoom's [`transform.rescaleX`](https://github.com/d3/d3-zoom#transform_rescaleX) function does.

#### Bar

The scale bar aesthetics are implemented with the d3-axis' `.domain` path. Instead of adding individual rectangles (which were a little tricky to update on zoom), the `.domain` path will get a solid stroke which will be modified with a `stroke-dasharray`. The intervals for the dasharray are calculated as disctances between each tick. Here's the structure of the miles axis:

<img width="1723" alt="screen shot 2018-08-03 at 16 56 41" src="https://user-images.githubusercontent.com/4750075/43654735-8d5efd48-974c-11e8-86ad-5f2b74f47f7f.png">

So far I have only played with equally spaced ticks as you can see in the image. The benefit, I guess, is that the axis is a little (not much) closer to a default D3-axis and might invite more styling options - either to bake in or for the user to implement. 

However, the `milesTickValues` and `kilometresTickValues` configurations are currently effect-less. The increased spacing as implemented on `master` would surely be possible but would need to be re-implemented. Another side-effect of close-to-default D3 axis is that the last value might not be displayed (see the kilometres bar in above image).

I also added a `barHeight` configuration that controls the - well - height of the bar (and the tick padding).

#### Decomposition

I sliced the code into four parts:

1. General measure calculations
2. Specific measure calculations for the chosen unit (e.g. miles)
3. Scale production
4. Legend Draw

Parts 2 to 4 are individual functions ([see the src folder](https://github.com/HarryStevens/d3-geo-scale-bar/tree/feature-zoom/src)) and can be called either for miles, kilometres, nautical miles, light years or else...

[Here's some example app code](https://gist.github.com/larsvers/d0474a97c0bd0f4aa4298dddc52ef948) that uses above implementation, but you can easily adjust your India example by adding _zoom_ and `scaleFactor` settings in the zoom handler.
